### PR TITLE
fix: keep chat streams alive and preserve scroll intent

### DIFF
--- a/sse.py
+++ b/sse.py
@@ -131,21 +131,25 @@ def stream_generator(q: queue.Queue):
     """Flask Response generator for SSE streaming.
 
     Yields SSE-formatted messages from the queue.
-    Sends a heartbeat comment every 30 seconds to keep the connection alive.
+    Sends an empty message every 30 seconds for the client's onmessage watchdog.
     """
     # Initial connection confirmation
     yield "event: connected\ndata: {}\n\n"
+    next_heartbeat = time.monotonic() + 30
     try:
         while True:
             try:
-                msg = q.get(timeout=30)
+                msg = q.get(timeout=max(0, next_heartbeat - time.monotonic()))
                 # None sentinel = forcible disconnect (admin suspend / self-delete)
                 if msg is None:
                     return
                 yield msg
             except queue.Empty:
-                # Heartbeat to keep connection alive
-                yield ": heartbeat\n\n"
+                pass
+            if time.monotonic() >= next_heartbeat:
+                # EventSource ignores comments; data dispatches onmessage.
+                yield "data: {}\n\n"
+                next_heartbeat = time.monotonic() + 30
     except GeneratorExit:
         pass
     finally:

--- a/templates/index.html
+++ b/templates/index.html
@@ -10444,6 +10444,7 @@ function _connectSSE() {
 function _sseAppendMessage(msg) {
   // Only render if we're on the companion/chat view
   if (!companionChatMessages) return;
+  const nearBottom = companionChatMessages.scrollHeight - companionChatMessages.scrollTop - companionChatMessages.clientHeight < 120;
   // Render using existing bubble functions; pass msg.time so the timeline
   // grouper can decide whether to insert a date separator / time anchor.
   const t = msg.time || null;
@@ -10455,8 +10456,8 @@ function _sseAppendMessage(msg) {
   }
   emptyCompanionState.style.display = 'none';
   // Auto-scroll if user is near bottom
-  const nearBottom = companionChatMessages.scrollHeight - companionChatMessages.scrollTop - companionChatMessages.clientHeight < 120;
   if (nearBottom) scrollCompanionChatToBottom();
+  else _showCompanionNewMsgBadge(true);
 }
 
 function _getDeviceId() {

--- a/tests/test_sse_delivery.py
+++ b/tests/test_sse_delivery.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+import queue
+import shutil
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import sse
+
+
+def test_idle_stream_heartbeat_reaches_eventsource_onmessage(monkeypatch):
+    clock = [0]
+    monkeypatch.setattr(sse, "time", SimpleNamespace(monotonic=lambda: clock[0]))
+    class IdleQueue:
+        def get(self, timeout):
+            clock[0] += timeout
+            raise queue.Empty
+
+    stream = sse.stream_generator(IdleQueue())
+    try:
+        assert next(stream).startswith("event: connected\n")
+        heartbeat = next(stream)
+        # Comments are invisible to EventSource; a default data event invokes
+        # the existing onmessage handler that resets the browser watchdog.
+        assert heartbeat.startswith("data: ")
+        assert json.loads(heartbeat.removeprefix("data: ").strip()) == {}
+    finally:
+        stream.close()
+
+
+def test_heartbeat_is_not_starved_by_named_events(monkeypatch):
+    clock = [0]
+    monkeypatch.setattr(sse, "time", SimpleNamespace(monotonic=lambda: clock[0]))
+    class BusyQueue:
+        def get(self, timeout):
+            clock[0] += 10
+            return 'event: chat_message\ndata: {}\n\n'
+
+    stream = sse.stream_generator(BusyQueue())
+    try:
+        assert next(stream).startswith("event: connected\n")
+        for _ in range(3):
+            assert next(stream).startswith("event: chat_message\n")
+        assert next(stream) == "data: {}\n\n"
+    finally:
+        stream.close()
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+@pytest.mark.parametrize("role,scroll_top,expected_scroll", [
+    ("assistant", 600, True),
+    ("user", 600, True),
+    ("assistant", 100, False),
+])
+def test_live_message_preserves_scroll_intent(role, scroll_top, expected_scroll):
+    source = (Path(__file__).resolve().parents[1] / "templates/index.html").read_text(encoding="utf-8")
+    start = source.index("function _sseAppendMessage(msg) {")
+    end = source.index("\nfunction _getDeviceId()", start)
+    harness = """
+const assert = require('assert');
+const companionChatMessages = {scrollHeight: 1000, scrollTop: SCROLL_TOP, clientHeight: 400};
+const emptyCompanionState = {style: {}};
+let scrolled = false, badge = false;
+function addCompanionReplyBubble() { companionChatMessages.scrollHeight += 500; }
+function addCompanionUserBubble() { companionChatMessages.scrollHeight += 500; }
+function scrollCompanionChatToBottom() { scrolled = true; }
+function _showCompanionNewMsgBadge(value) { badge = value; }
+function _assetUrl(value) { return value; }
+""".replace("SCROLL_TOP", str(scroll_top))
+    # Append the production function unchanged after configuring the fixture.
+    harness += source[start:end]
+    harness += "\n_sseAppendMessage(" + json.dumps({"role": role, "text": "long reply"}) + ");\n"
+    harness += "assert.strictEqual(scrolled, " + json.dumps(expected_scroll) + ");\n"
+    harness += "assert.strictEqual(badge, " + json.dumps(not expected_scroll) + ");\n"
+    result = subprocess.run(["node"], input=harness, text=True, capture_output=True, timeout=10)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
When another device appends a long chat message, the reader can remain above it even when previously at the bottom. Comment-only SSE heartbeats also never reach EventSource.onmessage, causing the 45-second watchdog to reconnect healthy streams.

Send observable heartbeats on a monotonic schedule, including during continuous named events, and capture scroll intent before inserting a message. Add five focused regression tests. Only sse.py, the chat template and delivery tests change.

Validation: full suite 874 passed (4 deselected, 5 expected failures); focused tests passed on Windows, macOS, Linux and Docker. The Android check compiles and exercises the existing Java SSE parser; it is not an emulator test. [Cross-platform results](https://github.com/Alice-Shimada/Miru/actions/runs/34185335575). Bidirectional chat was also checked in the actual Windows and Ubuntu main windows.
