### PR TITLE
feat(linux): add X11 desktop launcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -3700,6 +3700,7 @@ def api_shutdown():
     def _do_shutdown():
         import time as _t
         _t.sleep(0.5)  # let the response reach the client
+        linux_desktop = _is_linux_desktop()
 
         # 1) Kill child processes (pet, etc.).
         # In Flask debug mode, _launch_full_stack runs in the *master*
@@ -3711,7 +3712,7 @@ def api_shutdown():
 
         # (a) Kill child PIDs saved to disk
         _pid_file = _pet_pid_dir() / ".child_pids"
-        if _pid_file.exists():
+        if _pid_file.exists() and not linux_desktop:
             try:
                 for _line in _pid_file.read_text().splitlines():
                     _cpid = int(_line.strip())
@@ -3753,6 +3754,11 @@ def api_shutdown():
             for proc in _pet_children_list:
                 if proc.poll() is None:
                     proc.kill()
+
+        # The Linux desktop owns Flask in a thread, not a reloader child.
+        # Its parent is the user's shell/session and must never be signalled.
+        if linux_desktop:
+            os._exit(0)
 
         # 2) Kill the Flask master process (reloader parent).
         #    On Windows, /T kills the entire tree rooted at the master,
@@ -4008,6 +4014,11 @@ _pet_env = None
 _pet_children_list = None
 
 
+def _is_linux_desktop(env=None):
+    env = os.environ if env is None else env
+    return sys.platform.startswith("linux") and env.get("MIRU_DESKTOP_PLATFORM") == "linux"
+
+
 def _pet_pid_dir():
     """Stable directory for .pet.pid — not _MEIPASS in PyInstaller."""
     from pathlib import Path
@@ -4026,6 +4037,7 @@ def _kill_pet():
     pid_file = pid_dir / ".pet.pid"
     child_pid_file = pid_dir / ".child_pids"
     pet_lock_file = pid_dir / "data" / ".pet.lock"
+    linux_desktop = _is_linux_desktop()
 
     def _terminate_pid(pid: int) -> None:
         if os.name == "nt":
@@ -4058,7 +4070,7 @@ def _kill_pet():
             except Exception:
                 pass
         _pet_process = None
-    elif pid_file.exists():
+    elif pid_file.exists() and not linux_desktop:
         try:
             old_pid = int(pid_file.read_text().strip())
             if os.name == "nt":
@@ -4076,6 +4088,10 @@ def _kill_pet():
                 pass  # already gone
         except Exception:
             pass
+
+    # Linux uses flock plus an owning-parent watcher, never persisted PIDs.
+    if linux_desktop:
+        return
 
     # Clean up PID/lock files so the next app launch always starts a fresh
     # visible pet instead of inheriting a hidden/stale singleton state.
@@ -4113,16 +4129,27 @@ def _find_tauri_binary():
 
 
 def _launch_pet_tauri(pet_url, pet_hotkey, env, cwd):
-    """Launch the Tauri pet binary with env-var config. Returns Popen or None."""
+    """Launch the native pet: Qt on Linux, Tauri on Windows/macOS."""
     import subprocess
-    tauri_bin = _find_tauri_binary()
-    if not tauri_bin:
-        return None
     pet_env = (env or os.environ).copy()
+    if _is_linux_desktop(pet_env):
+        from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+        parts = urlsplit(pet_url)
+        query = dict(parse_qsl(parts.query, keep_blank_values=True))
+        query["desktop_platform"] = "linux"
+        pet_url = urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+        from pathlib import Path
+        command = [sys.executable, "-s", str(Path(__file__).resolve().parent / "linux_pet.py")]
+        pet_env["AIRI_PET_PARENT_PID"] = str(os.getpid())
+    else:
+        tauri_bin = _find_tauri_binary()
+        if not tauri_bin:
+            return None
+        command = [str(tauri_bin)]
     pet_env["AIRI_PET_URL"] = pet_url
     pet_env["AIRI_PET_HOTKEY"] = pet_hotkey
-    print(f"[pet] Starting Tauri pet → {pet_url}  (hotkey: {pet_hotkey})")
-    return subprocess.Popen([str(tauri_bin)], cwd=cwd, env=pet_env)
+    print(f"[pet] Starting native pet (hotkey: {pet_hotkey})")
+    return subprocess.Popen(command, cwd=cwd, env=pet_env)
 
 
 def _respawn_pet():
@@ -4156,7 +4183,8 @@ def _respawn_pet():
 
         # Write PID file
         try:
-            (_pet_pid_dir() / ".pet.pid").write_text(str(pet.pid))
+            if not _is_linux_desktop():
+                (_pet_pid_dir() / ".pet.pid").write_text(str(pet.pid))
         except Exception:
             pass
 
@@ -4211,6 +4239,7 @@ def _launch_full_stack():
         _pid_dir = ROOT
 
     env = os.environ.copy()
+    use_pid_files = not _is_linux_desktop(env)
 
     children: list[subprocess.Popen] = []
     global _pet_children_list, _pet_env
@@ -4221,6 +4250,8 @@ def _launch_full_stack():
 
     def _save_child_pids():
         """Persist child PIDs to disk so the Flask worker can read them on shutdown."""
+        if not use_pid_files:
+            return
         try:
             pids = [str(p.pid) for p in children if p.poll() is None]
             _child_pid_file.write_text("\n".join(pids), encoding="utf-8")
@@ -4247,6 +4278,8 @@ def _launch_full_stack():
         for proc in children:
             if proc.poll() is None:
                 proc.kill()
+        if not use_pid_files:
+            return
         # Remove pet PID file
         try:
             (_pet_pid_dir() / ".pet.pid").unlink(missing_ok=True)
@@ -4271,7 +4304,7 @@ def _launch_full_stack():
 
         # Check if a pet process is already running (PID file guard)
         pet_pid_file = _pid_dir / ".pet.pid"
-        if pet_pid_file.exists():
+        if use_pid_files and pet_pid_file.exists():
             try:
                 old_pid = int(pet_pid_file.read_text().strip())
                 # Check if old process is still alive
@@ -4317,7 +4350,8 @@ def _launch_full_stack():
 
         # Write PID file for duplicate-guard
         try:
-            pet_pid_file.write_text(str(pet.pid))
+            if use_pid_files:
+                pet_pid_file.write_text(str(pet.pid))
         except Exception:
             pass
         _save_child_pids()

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -58,6 +58,22 @@ powershell -ExecutionPolicy Bypass -File .\build_windows.ps1
 The installer is created under `dist\windows-installer\`. The public build is
 not Authenticode-signed.
 
+## Ubuntu 22.04 desktop (X11 preview)
+
+This source-run client uses PySide6/Qt WebEngine. Run it inside an X11 desktop
+session; Wayland is not supported. Obtain the desktop Live2D files listed above.
+
+```bash
+sudo apt-get install python3-venv libxcb-cursor0 libxkbcommon-x11-0
+python3 -m venv .venv
+.venv/bin/python -m pip install -r requirements-linux.txt
+.venv/bin/python -s linux_launcher.py
+```
+
+The default pet shortcut is `Ctrl+Alt+M`. Closing the main window exits the
+client; minimizing keeps it running. Data is stored under
+`${XDG_DATA_HOME:-~/.local/share}/Miru`. No Linux installer package is built.
+
 ## Android arm64
 
 Prerequisites: Node.js, Java 21, Android SDK, NDK 27.3.13750724, Python 3.12,

--- a/linux_launcher.py
+++ b/linux_launcher.py
@@ -1,0 +1,36 @@
+"""Linux desktop entry point; shares the existing desktop lifecycle/bridge."""
+import os
+import sys
+
+
+def x11_session_available():
+    session = os.environ.get("XDG_SESSION_TYPE", "").strip().lower()
+    return bool(os.environ.get("DISPLAY")) and session != "wayland" and (
+        session == "x11" or not os.environ.get("WAYLAND_DISPLAY"))
+
+
+def configure_qt():
+    os.environ["QT_API"] = "pyside6"
+    # Keep WebGL while avoiding NVIDIA DMA-BUF import failures on X11.
+    flags = os.environ.get("QTWEBENGINE_CHROMIUM_FLAGS", "")
+    if "--disable-gpu-compositing" not in flags:
+        os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = (flags + " --disable-gpu-compositing").strip()
+
+
+def main():
+    if not sys.platform.startswith("linux"):
+        raise RuntimeError("linux_launcher.py must run on Linux")
+    if not os.environ.get("DISPLAY"):
+        print("Start Miru inside your Ubuntu X11 desktop session.", file=sys.stderr)
+        return 1
+    if not x11_session_available():
+        print("This preview requires Ubuntu on Xorg (Wayland capture is not implemented).", file=sys.stderr)
+        return 1
+    from windows_launcher import main as desktop_main
+    os.environ["MIRU_DESKTOP_PLATFORM"] = "linux"
+    configure_qt()
+    return desktop_main(platform_name="linux")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/linux_pet.py
+++ b/linux_pet.py
@@ -1,0 +1,305 @@
+"""X11 desktop pet using Qt/Chromium and the existing Miru pet page."""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import threading
+import time
+from urllib.parse import urlsplit
+import webbrowser
+
+from Xlib import X, XK, display, protocol
+from Xlib.ext import shape
+
+from desktop_paths import app_support_dir
+from linux_launcher import configure_qt
+
+
+def _parse_hotkey(text):
+    spec = str(text).lower()
+    if spec.endswith("++"):
+        spec = spec[:-1] + "plus"
+    parts = spec.split("+")
+    modifiers = {"ctrl": X.ControlMask, "control": X.ControlMask,
+                 "alt": X.Mod1Mask, "option": X.Mod1Mask,
+                 "shift": X.ShiftMask, "super": X.Mod4Mask, "meta": X.Mod4Mask,
+                 "cmd": X.Mod4Mask, "command": X.Mod4Mask, "win": X.Mod4Mask}
+    mask = 0
+    for part in parts[:-1]:
+        part = part.strip()
+        if part not in modifiers:
+            raise ValueError("Unsupported hotkey modifier: " + part)
+        mask |= modifiers[part]
+    if not mask:
+        raise ValueError("A hotkey needs at least one modifier")
+    names = {"enter": "Return", "return": "Return", "escape": "Escape", "esc": "Escape",
+             "arrowup": "Up", "arrowdown": "Down", "arrowleft": "Left", "arrowright": "Right",
+             "tab": "Tab", "backspace": "BackSpace", "delete": "Delete", "insert": "Insert",
+             "home": "Home", "end": "End", "pageup": "Page_Up", "pagedown": "Page_Down",
+             " ": "space", "space": "space"}
+    key = parts[-1] if parts[-1] == " " else parts[-1].strip()
+    key = names.get(key, key.upper() if key.startswith("f") and key[1:].isdigit() else key)
+    keysym = ord(key) if len(key) == 1 else XK.string_to_keysym(key)
+    if not keysym:
+        raise ValueError("Unsupported hotkey key")
+    return mask, keysym
+
+
+def _cursor_payload(state, logical_width, logical_height, pass_through):
+    cx, cy, x, y, width, height = state
+    scale_x, scale_y = width / logical_width, height / logical_height
+    return {"cursor": {"x": cx / scale_x, "y": cy / scale_y},
+            "window": {"x": x / scale_x, "y": y / scale_y,
+                       "width": logical_width, "height": logical_height},
+            "local": {"x": (cx - x) / scale_x, "y": (cy - y) / scale_y},
+            "insideWindow": x <= cx < x + width and y <= cy < y + height,
+            "coordinateSpace": "logical", "passThrough": pass_through}
+
+
+def _watch_parent(parent_pid, stopped):
+    # Popen is called from a short-lived thread, so PR_SET_PDEATHSIG would
+    # fire when that thread exits. Observe the owning process instead.
+    while not stopped.is_set():
+        if os.getppid() != parent_pid:
+            os._exit(0)
+        stopped.wait(.5)
+
+
+class PetApi:
+    def __init__(self):
+        self._window = None
+        self._display = display.Display()
+        self._root = self._display.screen().root
+        self._lock = threading.RLock()
+        self._native_window = None
+        self._stopped = threading.Event()
+        self._monitoring = False
+        self._hidden = False
+        self._pass_through = False
+        self._drag = None
+        self._hotkey = None
+
+    def _native(self):
+        if self._native_window is not None:
+            return self._native_window
+        atom = self._display.intern_atom("_NET_CLIENT_LIST")
+        clients = self._root.get_full_property(atom, X.AnyPropertyType)
+        ids = clients.value if clients is not None else [w.id for w in self._root.query_tree().children]
+        for wid in ids:
+            window = self._display.create_resource_object("window", int(wid))
+            pid = window.get_full_property(self._display.intern_atom("_NET_WM_PID"), X.AnyPropertyType)
+            if pid is not None and int(pid.value[0]) == os.getpid() and window.get_wm_name() == "ContextLife AIRI Pet":
+                self._native_window = window
+                self._root.send_event(protocol.event.ClientMessage(
+                    window=window, client_type=self._display.intern_atom("_NET_WM_STATE"),
+                    data=(32, [1, self._display.intern_atom("_NET_WM_STATE_SKIP_TASKBAR"),
+                               self._display.intern_atom("_NET_WM_STATE_SKIP_PAGER"), 1, 0])),
+                    event_mask=X.SubstructureRedirectMask | X.SubstructureNotifyMask)
+                self._display.flush()
+                return window
+        return None
+
+    def _pass(self, enabled):
+        with self._lock:
+            native = self._native()
+            if native is None:
+                return
+            geometry = native.get_geometry()
+            native.shape_rectangles(shape.SO.Set, shape.SK.Input, X.Unsorted, 0, 0,
+                                    [] if enabled else [(0, 0, geometry.width, geometry.height)])
+            self._display.sync()
+            self._pass_through = bool(enabled)
+
+    def _register_hotkey(self, text):
+        mask, keysym = _parse_hotkey(text)
+        with self._lock:
+            code = self._display.keysym_to_keycode(keysym)
+            if not code:
+                raise ValueError("Hotkey is not available in the current keyboard layout")
+            if self._hotkey == (code, mask):
+                return text
+            errors = []
+            for extra in (0, X.LockMask, X.Mod2Mask, X.LockMask | X.Mod2Mask):
+                self._root.grab_key(code, mask | extra, False, X.GrabModeAsync, X.GrabModeAsync,
+                                   onerror=lambda error, request: errors.append(error))
+            self._display.sync()
+            if errors:
+                for extra in (0, X.LockMask, X.Mod2Mask, X.LockMask | X.Mod2Mask):
+                    self._root.ungrab_key(code, mask | extra)
+                self._display.sync()
+                raise RuntimeError("Hotkey is already used by another application")
+            if self._hotkey:
+                old_code, old_mask = self._hotkey
+                for extra in (0, X.LockMask, X.Mod2Mask, X.LockMask | X.Mod2Mask):
+                    self._root.ungrab_key(old_code, old_mask | extra)
+            self._hotkey = (code, mask)
+        return text
+
+    def _snap(self, anchor="bottom-right"):
+        import webview
+        screens = webview.screens
+        screen = next((s for s in screens if s.x <= self._window.x < s.x + s.width
+                       and s.y <= self._window.y < s.y + s.height), screens[0])
+        width, height = self._window.width, self._window.height
+        x = screen.x + screen.width - width - 26
+        if anchor == "bottom-left":
+            x = screen.x + 26
+        elif anchor == "bottom-center":
+            x = screen.x + (screen.width - width) / 2
+        self._window.move(max(screen.x, int(x)), max(screen.y, int(screen.y + screen.height - height - 26)))
+
+    def invoke(self, command, args=None):
+        args = args or {}
+        if command == "start_airi_pet_monitor":
+            self._monitoring = True
+        elif command == "stop_airi_pet_monitor":
+            self._monitoring = False
+            self._pass(False)
+        elif command == "set_airi_window_pass_through":
+            self._pass(bool(args.get("enabled")))
+        elif command == "get_airi_window_position":
+            return [self._window.x, self._window.y]
+        elif command == "move_airi_window":
+            self._window.move(int(args["x"]), int(args["y"]))
+        elif command == "start_airi_window_drag":
+            self._pass(False)
+            x, y = self._window.x, self._window.y
+            with self._lock:
+                pointer = self._root.query_pointer()
+                native = self._native()
+                scale = native.get_geometry().width / self._window.width if native else 1
+                self._drag = (pointer.root_x, pointer.root_y, x, y, scale)
+        elif command == "update_airi_window_drag":
+            with self._lock:
+                pointer = self._root.query_pointer()
+                drag = self._drag
+            if drag:
+                cx, cy, x, y, scale = drag
+                self._window.move(int(x + (pointer.root_x - cx) / scale), int(y + (pointer.root_y - cy) / scale))
+        elif command == "end_airi_window_drag":
+            self._drag = None
+        elif command == "resize_airi_window":
+            width = args.get("width", {"small": 280, "large": 560}.get(args.get("preset"), 420))
+            width = max(160, min(900, int(width)))
+            height = max(290, min(1630, int(args.get("height", width * 760 / 420))))
+            self._window.resize(width, height)
+            deadline = time.monotonic() + 2
+            while (self._window.width, self._window.height) != (width, height):
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("Qt window resize did not finish")
+                time.sleep(.01)
+            self._pass(False)
+            self._snap(args.get("anchor") or "bottom-right")
+            return [width, height]
+        elif command == "scale_airi_window":
+            width = max(160, min(900, round(self._window.width * float(args["factor"]))))
+            return self.invoke("resize_airi_window", {"width": width})
+        elif command == "snap_airi_window":
+            self._snap(args.get("anchor") or "bottom-right")
+        elif command == "hide_airi_window":
+            self._pass(False)
+            self._hidden = True
+            self._window.hide()
+        elif command == "close_airi_window":
+            self._window.destroy()
+        elif command == "elevate_airi_window":
+            return None
+        elif command == "update_global_hotkey":
+            return self._register_hotkey(args["hotkey"])
+        elif command == "open_external_url":
+            url = str(args.get("url", ""))
+            if urlsplit(url).scheme not in {"http", "https"}:
+                raise ValueError("Unsupported URL scheme")
+            webbrowser.open(url)
+        else:
+            raise ValueError("Unsupported pet command: " + command)
+
+    def _run(self):
+        try:
+            self._register_hotkey(os.environ.get("AIRI_PET_HOTKEY", "ctrl+alt+m"))
+        except Exception as error:
+            print(f"[LinuxPet] {error}", flush=True)
+        previous = None
+        samples = 0
+        last_emit = 0.0
+        while not self._stopped.wait(.048):
+            try:
+                toggle = False
+                with self._lock:
+                    while self._display.pending_events():
+                        event = self._display.next_event()
+                        if event.type == X.KeyPress and self._hotkey and event.detail == self._hotkey[0]:
+                            toggle = True
+                if toggle:
+                    self._pass(False)
+                    self._hidden = not self._hidden
+                    self._window.hide() if self._hidden else self._window.show()
+                if not self._monitoring or self._hidden:
+                    continue
+                with self._lock:
+                    native = self._native()
+                    if native is None:
+                        continue
+                    geometry = native.get_geometry()
+                    position = self._root.translate_coords(native, 0, 0)
+                    cursor = self._root.query_pointer()
+                state = (cursor.root_x, cursor.root_y, position.x, position.y, geometry.width, geometry.height)
+                now = time.monotonic()
+                if state == previous and samples >= 5 and now - last_emit < .25:
+                    continue
+                previous = state
+                samples += 1
+                last_emit = now
+                payload = _cursor_payload(state, self._window.width, self._window.height, self._pass_through)
+                self._window.evaluate_js("window.dispatchEvent(new CustomEvent('contextlife://pet-cursor', {detail:"
+                                        + json.dumps(payload) + "}))")
+            except Exception as error:
+                if self._stopped.is_set():
+                    break
+                print(f"[LinuxPet] monitor retry: {error}", flush=True)
+                with self._lock:
+                    self._native_window = None
+                previous = None
+                self._stopped.wait(.5)
+
+
+def main():
+    expected_parent = os.environ.get("AIRI_PET_PARENT_PID")
+    if expected_parent:
+        expected_parent = int(expected_parent)
+        if expected_parent != os.getppid():
+            return 0
+    configure_qt()
+    import webview
+
+    support = app_support_dir()
+    support.mkdir(parents=True, exist_ok=True)
+    singleton = open(support / "qt-pet.lock", "a+")
+    try:
+        fcntl.flock(singleton.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        singleton.close()
+        return 0
+    api = PetApi()
+    if expected_parent:
+        threading.Thread(target=_watch_parent, args=(expected_parent, api._stopped), daemon=True).start()
+    api._window = webview.create_window(
+        "ContextLife AIRI Pet", os.environ.get("AIRI_PET_URL", "http://127.0.0.1:5001/pet?desktop_platform=linux"),
+        js_api=api, width=420, height=760, min_size=(160, 290),
+        frameless=True, transparent=True, on_top=True, easy_drag=False)
+    api._window.events.closed += api._stopped.set
+    storage = support / "pet-webview"
+    storage.mkdir(exist_ok=True)
+    try:
+        webview.start(api._run, gui="qt", private_mode=False, storage_path=str(storage))
+    finally:
+        api._stopped.set()
+        with api._lock:
+            api._display.close()
+        singleton.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pywebview[pyside6]>=6.2.1,<7
+python-xlib>=0.33

--- a/templates/index.html
+++ b/templates/index.html
@@ -5896,7 +5896,9 @@ function settingsRenderAiPanel() {
       ? '这部手机中'
       : window.__MIRU_DESKTOP_PLATFORM__ === 'windows'
         ? '这台 Windows 电脑中'
-        : '这台 Mac 中')
+        : window.__MIRU_DESKTOP_PLATFORM__ === 'linux'
+          ? '这台 Linux 电脑中'
+          : '这台 Mac 中')
     : '当前 Miru 私有服务器中';
   html += '<div style="max-width:860px;">';
   html += '<div style="font-size:13px;color:var(--text-secondary);line-height:1.7;margin-bottom:16px;">';
@@ -6959,6 +6961,8 @@ function settingsRenderSystemPanel() {
       ? '当前是本地单设备模式。切换账号只会退出当前界面，不会删除这部手机上的本地 Miru 数据。'
       : isWindowsDesktop
       ? '当前是本地单设备模式。切换账号只会退出当前界面，不会删除这台 Windows 电脑上的本地 Miru 数据。'
+      : window.__MIRU_DESKTOP_PLATFORM__ === 'linux'
+      ? '当前是本地单设备模式。切换账号只会退出当前界面，不会删除这台 Linux 电脑上的本地 Miru 数据。'
       : '当前是本地单设备模式。切换账号只会退出当前界面，不会删除这台 Mac 上的本地 Miru 数据。')
     : '当前是多设备模式。切换账号只会清掉这台设备的登录状态，服务器里的 Miru 数据不会被删除。';
   html += '<div style="font-size:13px;color:var(--text-muted);line-height:1.6;margin-bottom:10px;">' + accountScopeText + '</div>';
@@ -7026,7 +7030,9 @@ function _loadSettingsInvitationCode() {
           ? '当前 Miru 只在这部手机上使用，其他设备不会同步。需要多设备时，请回到首启页选择私有服务器。'
           : window.__MIRU_DESKTOP_PLATFORM__ === 'windows'
             ? '当前 Miru 只在这台 Windows 电脑上使用，手机和其他电脑不会同步。需要多设备时，请回到首启页选择私有服务器。'
-            : '当前 Miru 只在这台 Mac 上使用，手机和其他电脑不会同步。需要多设备时，请回到首启页选择私有服务器。';
+            : window.__MIRU_DESKTOP_PLATFORM__ === 'linux'
+              ? '当前 Miru 只在这台 Linux 电脑上使用，手机和其他电脑不会同步。需要多设备时，请回到首启页选择私有服务器。'
+              : '当前 Miru 只在这台 Mac 上使用，手机和其他电脑不会同步。需要多设备时，请回到首启页选择私有服务器。';
       }
       return;
     }
@@ -7097,6 +7103,8 @@ async function settingsSwitchAccount() {
       ? '要回到 Miru 初始界面吗？\n\n本地单设备数据会继续留在这部手机上。之后再次选择“只在这部手机使用”，会回到同一个本地 Miru。'
       : isWindowsDesktop
       ? '要回到 Miru 初始界面吗？\n\n本地单设备数据会继续留在这台 Windows 电脑上。之后再次选择“只在这台电脑使用”，会回到同一个本地 Miru。'
+      : window.__MIRU_DESKTOP_PLATFORM__ === 'linux'
+      ? '要回到 Miru 初始界面吗？\n\n本地单设备数据会继续留在这台 Linux 电脑上。之后再次选择“只在这台电脑使用”，会回到同一个本地 Miru。'
       : '要回到 Miru 初始界面吗？\n\n本地单设备数据会继续留在这台 Mac 上。之后再次选择“只在这台 Mac 使用”，会回到同一个本地 Miru。')
     : '要回到 Miru 初始界面吗？\n\n这只会退出这台设备，不会删除服务器上的聊天、记忆或邀请码。';
   if (!await _confirm(msg, { confirmText: '切换账号' })) return;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6837,7 +6837,7 @@ async function settingsSaveSoul() {
 function settingsRenderSystemPanel() {
   const cfg = appConfigState || {};
   const isWindowsDesktop = window.__MIRU_DESKTOP_PLATFORM__ === 'windows';
-  const hotkeyExample = isWindowsDesktop ? 'Ctrl+Alt+M' : '⌘⌥M';
+  const hotkeyExample = (isWindowsDesktop || window.__MIRU_DESKTOP_PLATFORM__ === 'linux') ? 'Ctrl+Alt+M' : '⌘⌥M';
   let html = '';
   html += '<div class="sync-settings-grid">';
 
@@ -12039,10 +12039,10 @@ function _showDesktopScreenshotGuide() {
         nativeChecked = true;
         window.MiruDesktop.checkScreenPermission().then(function(res) {
           var nativePlatform = (res && res.platform) || window.__MIRU_DESKTOP_PLATFORM__ || 'macos';
-          if (nativePlatform === 'windows') {
+          if (nativePlatform === 'windows' || nativePlatform === 'linux') {
             // Capability is not consent. Do not capture or enable anything
-            // until the user explicitly clicks the Windows modal button.
-            _maybeShowModalFallback('windows');
+            // until the user explicitly clicks the capture-test button.
+            _maybeShowModalFallback(nativePlatform);
             return;
           }
           if (res && res.ok && res.granted === true) {
@@ -12124,18 +12124,21 @@ function _showClientScreenRecordingModal(alreadyEnabled, reason, platformName) {
   // path even if an in-app navigation accidentally loses desktop query tags.
   if (!resolvedPlatform && window.pywebview && window.pywebview.api) resolvedPlatform = 'windows';
   if (resolvedPlatform === 'win32') resolvedPlatform = 'windows';
-  var isWindows = resolvedPlatform === 'windows';
+  var isLinux = resolvedPlatform === 'linux';
+  var usesCaptureProbe = resolvedPlatform === 'windows' || isLinux;
   var overlay = document.createElement('div');
   overlay.id = 'permModalOverlay';
   overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:4000;display:flex;align-items:center;justify-content:center;padding:20px;animation:fadeIn 0.25s ease;';
   var charName = (window.CHARACTER && CHARACTER.name) || 'Miru';
-  var heading = isWindows && isDisabled
+  var heading = usesCaptureProbe && isDisabled
     ? '屏幕观察暂时中断'
     : (isDisabled
       ? (escapeHtml(charName) + ' 一直没能看到屏幕')
       : ('让 ' + escapeHtml(charName) + ' 能陪在你身边'));
   var body;
-  if (isWindows) {
+  if (isLinux) {
+    body = 'Linux 预览版支持 X11 桌面。开启后会定时读取屏幕，并将内容发给你配置的视觉模型；点击测试成功后才会开启。Wayland 暂不支持。';
+  } else if (resolvedPlatform === 'windows') {
     body = isDisabled
       ? ('Windows 不需要单独授予屏幕录制权限。请回到正常桌面，离开锁屏、UAC 确认或远程桌面切换界面后重新测试。')
       : (escapeHtml(charName) + ' 会定时看一眼鼠标所在的显示器，用来理解你正在做什么。Windows 不需要单独授予屏幕录制权限，测试成功后才会开启。');
@@ -12150,7 +12153,7 @@ function _showClientScreenRecordingModal(alreadyEnabled, reason, platformName) {
           '这需要 macOS 的 <b>屏幕录制</b> 权限。点下面的按钮会直接打开系统设置页面，勾选 <b>Miru</b> 即可。'
         );
   }
-  var lifecycleText = isWindows
+  var lifecycleText = usesCaptureProbe
     ? '• 关闭主窗口会完全退出并停止截屏；最小化会继续运行'
     : '• 完全退出 Miru 后会停止截屏';
   overlay.innerHTML = (
@@ -12165,18 +12168,18 @@ function _showClientScreenRecordingModal(alreadyEnabled, reason, platformName) {
       '</div>' +
       '<div id="permModalError" style="display:none;color:var(--fn-danger);font-size:12px;line-height:1.5;margin:-6px 0 12px;"></div>' +
       '<div style="display:flex;gap:10px;flex-direction:column;">' +
-        (isWindows
+        (usesCaptureProbe
           ? '<button id="permModalEnableBtn" onclick="_permModalEnableWindows()" style="border:none;background:var(--airi-pink);color:#fff;border-radius:10px;padding:12px;font-size:14px;font-weight:500;cursor:pointer;">' + (isDisabled ? '重新测试截屏' : '测试并开启屏幕观察') + '</button>'
           : '<button onclick="_permModalOpenSettings()" style="border:none;background:var(--airi-pink);color:#fff;border-radius:10px;padding:12px;font-size:14px;font-weight:500;cursor:pointer;">打开系统设置 → 屏幕录制</button>') +
         // "立即重试" only makes sense when sensor has backed off — otherwise
         // there's nothing to retry. Hide on the first-launch modal.
-        (isDisabled && !isWindows
+        (isDisabled && !usesCaptureProbe
           ? '<button onclick="_permModalRetryNow()" style="border:none;background:rgba(192,104,120,0.12);color:var(--airi-pink-deep,#C06878);border-radius:10px;padding:10px;font-size:13px;cursor:pointer;">我已授权，立即重试</button>'
           : '') +
         // "我已经设置好了" — latches the sticky flag so this modal
         // never appears again. Styled as a proper outline button (not a
         // muted link) so users actually see it as a real confirm action.
-        (isWindows
+        (usesCaptureProbe
           ? '<button onclick="_permModalDismissWithoutEnable()" style="border:1px solid var(--airi-pink);background:transparent;color:var(--airi-pink-deep,#C06878);border-radius:10px;padding:10px;font-size:13px;font-weight:500;cursor:pointer;">暂不开启</button>'
           : '<button onclick="_permModalDismiss()" style="border:1px solid var(--airi-pink);background:transparent;color:var(--airi-pink-deep,#C06878);border-radius:10px;padding:10px;font-size:13px;font-weight:500;cursor:pointer;">我已经设置好了</button>') +
       '</div>' +
@@ -12195,7 +12198,7 @@ async function _permModalEnableWindows() {
   if (error) error.style.display = 'none';
   try {
     if (!window.MiruDesktop || typeof window.MiruDesktop.probeScreenCapture !== 'function') {
-      throw new Error('Windows 本机桥接尚未准备好，请稍后重试。');
+      throw new Error('本机桥接尚未准备好，请稍后重试。');
     }
     var result = await window.MiruDesktop.probeScreenCapture();
     if (!result || !result.ok) throw new Error((result && result.error) || '截屏测试失败。');

--- a/templates/pet.html
+++ b/templates/pet.html
@@ -466,6 +466,8 @@ function _write(k, v) { try { localStorage.setItem(k, String(v)); } catch(e) {} 
 
 // ── Tauri IPC ──
 function _getInvoke() {
+  if (window.pywebview && window.pywebview.api && window.pywebview.api.invoke)
+    return function(command, args) { return window.pywebview.api.invoke(command, args || {}); };
   if (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
     return window.__TAURI__.core.invoke;
   if (window.__TAURI_INTERNALS__ && window.__TAURI_INTERNALS__.invoke)
@@ -487,6 +489,13 @@ function _tauriListen(eventName, handler) {
 }
 
 function _getEventApi() {
+  if (window.pywebview && window.pywebview.api && window.pywebview.api.invoke) {
+    return { listen: function(name, handler) {
+      var listener = function(event) { handler({payload: event.detail}); };
+      window.addEventListener(name, listener);
+      return Promise.resolve(function() { window.removeEventListener(name, listener); });
+    }};
+  }
   if (window.__TAURI__ && window.__TAURI__.event) return window.__TAURI__.event;
   // Fallback: build a minimal event API from __TAURI_INTERNALS__
   var internals = window.__TAURI_INTERNALS__;
@@ -686,16 +695,18 @@ async function _initPetCanvas() {
   // reports devicePixelRatio=1 even on Retina displays — known WebKit
   // behavior for windows with setOpaque:false + clearColor background.
   // Force at least 2x so the Live2D model stays crisp.
-  var renderRes = Math.max(2, window.devicePixelRatio || 1);
+  var isLinuxPet = new URLSearchParams(window.location.search).get('desktop_platform') === 'linux';
+  var renderRes = isLinuxPet ? (window.devicePixelRatio || 1) : Math.max(2, window.devicePixelRatio || 1);
 
   _petApp = new PIXI.Application({
     width: w, height: h,
     backgroundAlpha: 0,
-    useContextAlpha: 'notMultiplied',
+    useContextAlpha: isLinuxPet ? true : 'notMultiplied',
     resolution: renderRes,
     autoDensity: true,
     antialias: true,
-    preserveDrawingBuffer: true,
+    // The Linux transparent Qt window needs fresh, premultiplied frames.
+    preserveDrawingBuffer: !isLinuxPet,
   });
   wrap.appendChild(_petApp.view);
 
@@ -1644,6 +1655,9 @@ async function _initTauriEvents() {
   await eventApi.listen('contextlife://pet-cursor', function(event) {
     var p = event.payload;
     if (!p) return;
+    if (window.pywebview && window.pywebview.api && typeof p.passThrough === 'boolean') {
+      _lastPassThrough = p.passThrough;
+    }
     _cursorEventsCount++;
     if (p.cursor && p.window) {
       var dpr = window.devicePixelRatio || 1;
@@ -1652,8 +1666,8 @@ async function _initTauriEvents() {
       var ww = p.window.width, wh = p.window.height;
 
       if (p.coordinateSpace === 'logical' && p.local) {
-        // macOS native side already converted NSEvent/NSWindow.frame into
-        // one logical top-left coordinate space. Trust it instead of
+        // The native side supplied one logical top-left coordinate space.
+        // This also handles fractional X11 scaling. Trust it instead of
         // guessing from devicePixelRatio; transparent WKWebViews can report
         // a transient or forced dpr that differs from the display backing.
         _cursorX = p.local.x;

--- a/tests/test_linux_launcher.py
+++ b/tests/test_linux_launcher.py
@@ -1,6 +1,7 @@
 from urllib.parse import parse_qs, urlsplit
 from pathlib import Path
 import ast
+import io
 import sys
 from types import SimpleNamespace
 
@@ -8,6 +9,80 @@ import pytest
 
 import linux_launcher
 import windows_launcher
+
+
+@pytest.mark.parametrize("failure", ["port-conflict", "flask-start"])
+def test_linux_startup_failures_remain_visible_in_terminal(monkeypatch, tmp_path, failure):
+    terminal = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", terminal)
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(windows_launcher, "DESKTOP_PLATFORM", "linux")
+    monkeypatch.setattr(windows_launcher, "app_support_dir", lambda: tmp_path)
+    monkeypatch.setattr(windows_launcher, "data_dir", lambda: tmp_path / "data")
+    monkeypatch.setattr(windows_launcher, "_existing_instance_ready", lambda: False)
+    monkeypatch.setattr(windows_launcher, "_port_in_use", lambda: failure == "port-conflict")
+    monkeypatch.setattr(windows_launcher, "_wait_for_flask", lambda: False)
+    monkeypatch.setattr(windows_launcher, "_load_config", lambda: {})
+    monkeypatch.setattr(windows_launcher.os, "chdir", lambda path: None)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setitem(sys.modules, "app", SimpleNamespace(run_client_mode=lambda *args: None))
+    try:
+        assert windows_launcher.main(platform_name="linux") == 1
+        expected = "Port 5001 is already in use" if failure == "port-conflict" else "Miru local service did not start"
+        assert expected in terminal.getvalue()
+        assert sys.stderr is terminal
+    finally:
+        if sys.stdout is not terminal:
+            sys.stdout.close()
+
+
+def test_linux_log_permissions_are_best_effort(monkeypatch, tmp_path):
+    terminal = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", terminal)
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.setattr(windows_launcher, "DESKTOP_PLATFORM", "linux")
+    monkeypatch.setattr(windows_launcher, "app_support_dir", lambda: tmp_path)
+    def unsupported(path, mode):
+        assert mode == 0o600
+        raise OSError("filesystem does not support chmod")
+    monkeypatch.setattr(windows_launcher.os, "chmod", unsupported)
+    windows_launcher._configure_logging()
+    try:
+        print("Linux log remains writable")
+        windows_launcher._show_error("Startup failure remains visible")
+        assert "Startup failure remains visible" in terminal.getvalue()
+        assert "Linux log remains writable" in (tmp_path / "logs" / "miru.log").read_text()
+    finally:
+        sys.stdout.close()
+
+
+@pytest.mark.parametrize("platform,frozen,has_terminal,redirected", [
+    ("windows", False, True, False), ("windows", True, True, True),
+    ("linux", True, True, True), ("linux", False, False, True),
+])
+def test_logging_preserves_packaged_and_windowless_behavior(monkeypatch, tmp_path,
+                                                          platform, frozen, has_terminal, redirected):
+    terminal = io.StringIO() if has_terminal else None
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", terminal)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "frozen", frozen, raising=False)
+    monkeypatch.setattr(windows_launcher, "DESKTOP_PLATFORM", platform)
+    monkeypatch.setattr(windows_launcher, "app_support_dir", lambda: tmp_path)
+    windows_launcher._configure_logging()
+    try:
+        if redirected:
+            assert sys.stderr is sys.stdout
+            assert Path(sys.stderr.name) == tmp_path / "logs" / "miru.log"
+        else:
+            assert sys.stderr is terminal
+            assert sys.stdout is stdout
+    finally:
+        if sys.stdout is not stdout:
+            sys.stdout.close()
 
 
 def test_linux_url_retains_auth_and_platform(monkeypatch):

--- a/tests/test_linux_launcher.py
+++ b/tests/test_linux_launcher.py
@@ -1,0 +1,164 @@
+from urllib.parse import parse_qs, urlsplit
+from pathlib import Path
+import ast
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import linux_launcher
+import windows_launcher
+
+
+def test_linux_url_retains_auth_and_platform(monkeypatch):
+    monkeypatch.setattr(windows_launcher, "DESKTOP_PLATFORM", "linux")
+    url = windows_launcher._initial_url({"auth_token": "test-token", "setup_complete": True})
+    query = parse_qs(urlsplit(url).query)
+    assert query["desktop_platform"] == ["linux"]
+    assert query["token"] == ["test-token"]
+
+
+def test_linux_capture_capability_is_not_consent(monkeypatch):
+    monkeypatch.setattr(windows_launcher, "DESKTOP_PLATFORM", "linux")
+    monkeypatch.setenv("DISPLAY", ":99")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    api = windows_launcher.MiruDesktopApi(None, {})
+    assert api.check_screen_permission() == {
+        "ok": True, "platform": "linux", "granted": True,
+        "requires_opt_in": True, "supported": True,
+    }
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    assert api.check_screen_permission()["supported"] is False
+
+
+def test_linux_launcher_rejects_ssh_without_display(monkeypatch):
+    monkeypatch.setattr(linux_launcher.sys, "platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    assert linux_launcher.main() == 1
+
+
+@pytest.mark.parametrize("session", ["wayland", "Wayland", "WAYLAND"])
+def test_linux_launcher_rejects_wayland(monkeypatch, session):
+    monkeypatch.setattr(linux_launcher.sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setenv("XDG_SESSION_TYPE", session)
+    assert linux_launcher.main() == 1
+
+
+def test_linux_launcher_delegates_to_shared_lifecycle(monkeypatch):
+    monkeypatch.setattr(linux_launcher.sys, "platform", "linux")
+    monkeypatch.setenv("DISPLAY", ":99")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    monkeypatch.delenv("MIRU_DESKTOP_PLATFORM", raising=False)
+    monkeypatch.delenv("QT_API", raising=False)
+    monkeypatch.delenv("QTWEBENGINE_CHROMIUM_FLAGS", raising=False)
+    calls = []
+    def delegate(**kw):
+        assert linux_launcher.os.environ["MIRU_DESKTOP_PLATFORM"] == "linux"
+        calls.append(kw)
+        return 7
+    monkeypatch.setattr(windows_launcher, "main", delegate)
+    assert linux_launcher.main() == 7
+    assert calls == [{"platform_name": "linux"}]
+
+
+def _app_namespace(name, platform="linux", **bindings):
+    # Test lifecycle boundaries without starting the Flask/model runtime.
+    import os
+    source = Path(__file__).resolve().parents[1] / "app.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)
+                 and node.name in {name, "_is_linux_desktop"}]
+    for function in functions:
+        function.decorator_list = []
+    namespace = {"os": os, "sys": SimpleNamespace(platform=platform, executable="test-python"),
+                 "__file__": str(source), "_find_tauri_binary": lambda: "tauri-pet"}
+    namespace.update(bindings)
+    exec(compile(ast.Module(body=functions, type_ignores=[]), str(source), "exec"), namespace)
+    return namespace
+
+
+@pytest.mark.parametrize("platform", ["linux", "win32", "darwin"])
+def test_pet_dispatch_preserves_auth_and_non_linux_command(monkeypatch, capsys, platform):
+    import subprocess
+    namespace = _app_namespace("_launch_pet_tauri", platform)
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda command, **kwargs: calls.append((command, kwargs)) or "child")
+    original_env = {"PATH": "test-path", "MIRU_DESKTOP_PLATFORM": "linux"}
+    url = "http://127.0.0.1:5001/pet?token=test-private-token#anchor"
+    assert namespace["_launch_pet_tauri"](url, "ctrl+alt+m", original_env, "test-root") == "child"
+    command, options = calls[0]
+    assert original_env == {"PATH": "test-path", "MIRU_DESKTOP_PLATFORM": "linux"}
+    assert options["env"]["AIRI_PET_HOTKEY"] == "ctrl+alt+m"
+    assert options["cwd"] == "test-root"
+    if platform == "linux":
+        assert command == ["test-python", "-s", str(Path(namespace["__file__"]).parent / "linux_pet.py")]
+        assert options["env"]["AIRI_PET_PARENT_PID"] == str(namespace["os"].getpid())
+        parsed = urlsplit(options["env"]["AIRI_PET_URL"])
+        assert parse_qs(parsed.query) == {"token": ["test-private-token"], "desktop_platform": ["linux"]}
+        assert parsed.fragment == "anchor"
+    else:
+        assert command == ["tauri-pet"]
+        assert options["env"]["AIRI_PET_URL"] == url
+    assert "test-private-token" not in capsys.readouterr().out
+
+
+def test_linux_server_does_not_start_qt_pet(monkeypatch):
+    import subprocess
+    namespace = _app_namespace("_launch_pet_tauri")
+    namespace["_find_tauri_binary"] = lambda: None
+    def unexpected_spawn(*args, **kwargs):
+        pytest.fail("server launched a Qt desktop process")
+    monkeypatch.setattr(subprocess, "Popen", unexpected_spawn)
+    assert namespace["_launch_pet_tauri"]("http://127.0.0.1:5001/pet", "ctrl+alt+m",
+                                           {"PATH": "test-path"}, "test-root") is None
+
+
+def test_xwayland_without_session_type_is_rejected(monkeypatch):
+    monkeypatch.setenv("DISPLAY", ":99")
+    monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    assert linux_launcher.x11_session_available() is False
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    assert linux_launcher.x11_session_available() is True
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux process cleanup")
+def test_linux_shutdown_ignores_stale_pid_files(monkeypatch, tmp_path):
+    import os
+    namespace = _app_namespace("_kill_pet", _pet_process=None, _pet_pid_dir=lambda: tmp_path)
+    monkeypatch.setenv("MIRU_DESKTOP_PLATFORM", "linux")
+    (tmp_path / ".pet.pid").write_text("12345")
+    monkeypatch.setattr(os, "kill", lambda *a: pytest.fail("signalled an unverified persisted PID"))
+    namespace["_kill_pet"]()
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux process cleanup")
+def test_linux_exit_api_stops_owned_children_without_signalling_parent(monkeypatch, tmp_path):
+    import os
+    import threading
+    import time
+    calls = []
+    class Child:
+        stopped = False
+        def poll(self):
+            return 0 if self.stopped else None
+        def terminate(self):
+            self.stopped = True
+            calls.append("owned-child")
+    namespace = _app_namespace("api_shutdown", _kill_pet=lambda: calls.append("pet"),
+                               _pet_pid_dir=lambda: tmp_path, _pet_children_list=[Child()],
+                               jsonify=lambda data: data)
+    monkeypatch.setenv("MIRU_DESKTOP_PLATFORM", "linux")
+    (tmp_path / ".child_pids").write_text("12345")
+    monkeypatch.setattr(os, "kill", lambda *a: pytest.fail("signalled an unrelated PID"))
+    monkeypatch.setattr(os, "getppid", lambda: pytest.fail("looked up the launching shell to kill"))
+    def exit_current(code):
+        raise SystemExit(code)
+    monkeypatch.setattr(os, "_exit", exit_current)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    monkeypatch.setattr(threading, "Thread", lambda target, **kw: SimpleNamespace(start=target))
+    with pytest.raises(SystemExit) as exit_info:
+        namespace["api_shutdown"]()
+    assert exit_info.value.code == 0
+    assert calls == ["pet", "owned-child"]

--- a/tests/test_linux_pet.py
+++ b/tests/test_linux_pet.py
@@ -1,0 +1,83 @@
+"""Linux native boundary regressions; no display or Qt application needed."""
+import json
+import sys
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+if not sys.platform.startswith("linux"):
+    pytest.skip("Linux-only native pet", allow_module_level=True)
+pytest.importorskip("Xlib")
+from Xlib import X, XK
+import linux_pet
+
+
+@pytest.mark.parametrize("spec,mask,key", [
+    ("ctrl+alt+m", X.ControlMask | X.Mod1Mask, "m"),
+    ("cmd+enter", X.Mod4Mask, "Return"),
+    ("command+arrowup", X.Mod4Mask, "Up"),
+    ("win+pageup", X.Mod4Mask, "Page_Up"),
+    ("ctrl+ ", X.ControlMask, "space"),
+    ("ctrl+shift++", X.ControlMask | X.ShiftMask, "plus"),
+    ("ctrl+f12", X.ControlMask, "F12"),
+    ("ctrl+.", X.ControlMask, "period"),
+])
+def test_recorded_hotkeys_map_to_x11(spec, mask, key):
+    assert linux_pet._parse_hotkey(spec) == (mask, XK.string_to_keysym(key))
+
+
+@pytest.mark.parametrize("spec", ["m", "enter", "ctrl+", "unknown+m", "ctrl+not-a-key"])
+def test_invalid_or_bare_hotkeys_do_not_grab_input(spec):
+    with pytest.raises(ValueError):
+        linux_pet._parse_hotkey(spec)
+
+
+@pytest.mark.parametrize("scale", [1, 1.25, 1.5, 2])
+def test_fractional_scale_cursor_coordinates(scale):
+    # Cursor is 100x150 logical pixels inside a window at an arbitrary origin.
+    state = (300 + 100 * scale, 200 + 150 * scale, 300, 200, 420 * scale, 760 * scale)
+    payload = linux_pet._cursor_payload(state, 420, 760, True)
+    assert payload["coordinateSpace"] == "logical"
+    assert payload["local"] == {"x": 100, "y": 150}
+    assert payload["window"]["width"] == 420
+    assert payload["insideWindow"] is True
+    assert payload["passThrough"] is True
+
+
+def test_monitor_recovers_after_transient_bridge_failure():
+    api = linux_pet.PetApi.__new__(linux_pet.PetApi)
+    api._stopped = threading.Event()
+    api._lock = threading.RLock()
+    api._monitoring, api._hidden, api._pass_through = True, False, False
+    api._hotkey, api._native_window = None, None
+    api._register_hotkey = lambda text: None
+    api._display = SimpleNamespace(pending_events=lambda: 0)
+    api._root = SimpleNamespace(
+        translate_coords=lambda *a: SimpleNamespace(x=300, y=200),
+        query_pointer=lambda: SimpleNamespace(root_x=425, root_y=387.5))
+    api._native = lambda: SimpleNamespace(get_geometry=lambda: SimpleNamespace(width=525, height=950))
+    calls = []
+    def evaluate(script):
+        calls.append(script)
+        if len(calls) == 1:
+            raise RuntimeError("temporary bridge failure")
+        api._stopped.set()
+    api._window = SimpleNamespace(width=420, height=760, evaluate_js=evaluate)
+    api._run()
+    assert len(calls) == 2
+    payload = json.loads(calls[-1].split("{detail:", 1)[1][:-3])
+    assert payload["local"] == {"x": 100, "y": 150}
+
+
+def test_parent_watcher_exits_only_after_reparenting(monkeypatch):
+    stopped = threading.Event()
+    parents = iter([123, 123, 1])
+    monkeypatch.setattr(linux_pet.os, "getppid", lambda: next(parents))
+    def exit_child(code):
+        raise SystemExit(code)
+    monkeypatch.setattr(linux_pet.os, "_exit", exit_child)
+    monkeypatch.setattr(stopped, "wait", lambda timeout: None)
+    with pytest.raises(SystemExit) as exit_info:
+        linux_pet._watch_parent(123, stopped)
+    assert exit_info.value.code == 0

--- a/tests/test_linux_settings_frontend.py
+++ b/tests/test_linux_settings_frontend.py
@@ -1,0 +1,83 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from test_windows_capture_recovery_frontend import _function_source
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+@pytest.mark.parametrize("platform,device", [
+    ("linux", "这台 Linux 电脑"), ("windows", "这台 Windows 电脑"),
+    ("macos", "这台 Mac"), ("android", "这部手机"),
+])
+@pytest.mark.parametrize("mode", ["local", "remote"])
+def test_settings_copy_matches_device_and_storage_scope(platform, device, mode):
+    html = (Path(__file__).resolve().parents[1] / "templates" / "index.html").read_text(encoding="utf-8")
+    functions = "\n".join(_function_source(html, name) for name in (
+        "settingsRenderAiPanel", "settingsRenderSystemPanel",
+        "_loadSettingsInvitationCode", "settingsSwitchAccount",
+    ))
+    fixture = json.dumps({"platform": platform, "device": device, "mode": mode}, ensure_ascii=False)
+    harness = "const fixture = " + fixture + ";\n" + r"""
+const assert = require('node:assert/strict');
+const window = { __MIRU_DESKTOP_PLATFORM__: fixture.platform };
+if (fixture.platform === 'android') window.MiruAndroid = {};
+const elements = Object.fromEntries([
+  'settingsPanelAi', 'settingsPanelSystem', 'settingsInvitationCode',
+  'settingsInvitationHint', 'settingsCopyInvitationBtn',
+].map(id => [id, { innerHTML: '', textContent: '' }]));
+const document = { getElementById: id => elements[id] || null };
+const localStorage = { getItem: () => null, removeItem: () => {} };
+const navigator = { platform: fixture.platform };
+const _clientModeMode = fixture.mode;
+const _isMobile = fixture.platform === 'android';
+const appConfigState = {};
+const settingsAiConfigState = {};
+const SETTINGS_AI_TIER_META = { vision: {}, chat: {}, memory: {} };
+const _settingsAiTier = () => ({});
+const _settingsAiStatusText = () => '';
+const _settingsEsc = String;
+const escapeHtml = String;
+const _formatHotkeyDisplay = String;
+const _updateAndroidCaptureUI = () => {};
+const _loadScreenshotStats = () => {};
+const fetch = async () => ({ ok: true, json: async () => (
+  fixture.mode === 'local' ? { local_only: true } : { ok: true, invitation_code: 'fixture-code' }
+) });
+let confirmation;
+const _confirm = async message => { confirmation = message; return false; };
+""" + functions + r"""
+(async () => {
+  settingsRenderAiPanel();
+  settingsRenderSystemPanel();
+  await new Promise(resolve => setImmediate(resolve));
+  await settingsSwitchAccount();
+  const ai = elements.settingsPanelAi.innerHTML;
+  const account = elements.settingsPanelSystem.innerHTML;
+  const invitation = elements.settingsInvitationHint.textContent;
+  if (fixture.mode === 'local') {
+    const device = fixture.device + (fixture.platform === 'macos' ? ' ' : '');
+    assert.ok(ai.includes('这些配置保存在' + device + '中。'), 'AI storage scope');
+    assert.ok(account.includes('不会删除' + device + '上的本地 Miru 数据'), 'account description');
+    assert.ok(invitation.includes('只在' + device + '上使用'), 'local invitation hint');
+    assert.ok(confirmation.includes('数据会继续留在' + device + '上'), 'switch confirmation');
+    if (fixture.platform === 'linux') {
+      assert.ok(confirmation.includes('“只在这台电脑使用”'));
+      for (const copy of [ai, account, invitation, confirmation]) assert.ok(!copy.includes('Mac'));
+    }
+  } else {
+    assert.ok(ai.includes('当前 Miru 私有服务器中'));
+    assert.ok(account.includes('服务器里的 Miru 数据不会被删除'));
+    assert.equal(elements.settingsInvitationCode.value, 'fixture-code');
+    assert.ok(confirmation.includes('不会删除服务器上的聊天、记忆或邀请码'));
+  }
+  console.log(JSON.stringify({ ok: true }));
+})().catch(error => { console.error(error.stack); process.exitCode = 1; });
+"""
+    result = subprocess.run(["node"], input=harness, capture_output=True,
+                            text=True, encoding="utf-8", timeout=10)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["ok"] is True

--- a/windows_launcher.py
+++ b/windows_launcher.py
@@ -139,10 +139,14 @@ def _configure_logging() -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
     stream = open(log_dir / "miru.log", "a", encoding="utf-8", buffering=1)
     if DESKTOP_PLATFORM == "linux":
-        os.chmod(log_dir / "miru.log", 0o600)
+        try:
+            os.chmod(log_dir / "miru.log", 0o600)
+        except OSError:
+            pass
     if getattr(sys, "frozen", False) or sys.stdout is None or DESKTOP_PLATFORM == "linux":
         sys.stdout = stream
-    if getattr(sys, "frozen", False) or sys.stderr is None or DESKTOP_PLATFORM == "linux":
+    # Source runs keep terminal stderr so startup failures remain visible.
+    if getattr(sys, "frozen", False) or sys.stderr is None:
         sys.stderr = stream
 
 

--- a/windows_launcher.py
+++ b/windows_launcher.py
@@ -1,8 +1,8 @@
-"""Miru Windows desktop launcher.
+"""Miru Windows/Linux desktop launcher.
 
-The packaged executable owns the local Flask client runtime, the WebView2
-main window, the screen sensor, and the Tauri pet sidecar. Closing the main
-window stops all of them; minimizing the window leaves them running.
+Owns the local Flask runtime, main window, screen sensor and pet sidecar.
+Windows uses WebView2/Tauri; Linux uses Qt. Closing the main window stops the
+runtime; minimizing leaves it running.
 """
 
 from __future__ import annotations
@@ -28,6 +28,7 @@ from desktop_paths import (
 
 
 PORT = 5001
+DESKTOP_PLATFORM = "windows"
 
 
 def _bundle_dir() -> Path:
@@ -58,7 +59,7 @@ def _desktop_url(url: str) -> str:
     parts = urlsplit(url)
     query = dict(parse_qsl(parts.query, keep_blank_values=True))
     query["desktop"] = "1"
-    query["desktop_platform"] = "windows"
+    query["desktop_platform"] = DESKTOP_PLATFORM
     return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
 
 
@@ -122,6 +123,9 @@ def _wait_for_flask(timeout: float = 20.0) -> bool:
 
 
 def _show_error(message: str) -> None:
+    print(message, file=sys.stderr)
+    if DESKTOP_PLATFORM != "windows":
+        return
     try:
         import ctypes
 
@@ -134,9 +138,11 @@ def _configure_logging() -> None:
     log_dir = app_support_dir() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     stream = open(log_dir / "miru.log", "a", encoding="utf-8", buffering=1)
-    if getattr(sys, "frozen", False) or sys.stdout is None:
+    if DESKTOP_PLATFORM == "linux":
+        os.chmod(log_dir / "miru.log", 0o600)
+    if getattr(sys, "frozen", False) or sys.stdout is None or DESKTOP_PLATFORM == "linux":
         sys.stdout = stream
-    if getattr(sys, "frozen", False) or sys.stderr is None:
+    if getattr(sys, "frozen", False) or sys.stderr is None or DESKTOP_PLATFORM == "linux":
         sys.stderr = stream
 
 
@@ -175,6 +181,11 @@ class MiruDesktopApi:
             return {"ok": False, "error": str(exc)}
 
     def check_screen_permission(self) -> dict:
+        if DESKTOP_PLATFORM == "linux":
+            from linux_launcher import x11_session_available
+            supported = x11_session_available()
+            return {"ok": True, "platform": "linux", "granted": supported,
+                    "requires_opt_in": True, "supported": supported}
         # Windows has no macOS-style TCC prompt. This only reports platform
         # capability; pixels are not captured until the user clicks Enable.
         return {
@@ -190,10 +201,10 @@ class MiruDesktopApi:
 
             instance = sensor.get_sensor()
             result = instance.probe_capture()
-            result["platform"] = "windows"
+            result["platform"] = DESKTOP_PLATFORM
             return result
         except Exception as exc:
-            return {"ok": False, "platform": "windows", "error": str(exc)}
+            return {"ok": False, "platform": DESKTOP_PLATFORM, "error": str(exc)}
 
     def notify_app_ready(self, payload: dict | None = None) -> dict:
         path = str((payload or {}).get("path") or "")
@@ -216,11 +227,11 @@ def _stop_runtime(app_module, state: dict) -> None:
             config = dict(app_module._client_mode_config or {})
         app_module._teardown_client_runtime(config)
     except Exception as exc:
-        print(f"[WindowsLauncher] client runtime stop failed: {exc}")
+        print(f"[DesktopLauncher] client runtime stop failed: {exc}")
     try:
         app_module._kill_pet()
     except Exception as exc:
-        print(f"[WindowsLauncher] pet stop failed: {exc}")
+        print(f"[DesktopLauncher] pet stop failed: {exc}")
 
 
 def _webview_bootstrap_ready(window) -> bool:
@@ -272,17 +283,20 @@ def _runtime_coordinator(window, app_module, state: dict) -> None:
                 app_module._launch_full_stack()
                 state["pet_launched"] = True
         except Exception as exc:
-            print(f"[WindowsLauncher] coordinator warning: {exc}")
+            print(f"[DesktopLauncher] coordinator warning: {exc}")
         time.sleep(0.25)
 
 
-def main() -> int:
-    if sys.platform != "win32":
-        raise RuntimeError("windows_launcher.py must run on Windows")
-
-    from windows.platform import set_process_dpi_awareness
-
-    set_process_dpi_awareness()
+def main(platform_name: str = "windows") -> int:
+    global DESKTOP_PLATFORM
+    DESKTOP_PLATFORM = platform_name
+    if platform_name == "windows":
+        if sys.platform != "win32":
+            raise RuntimeError("windows_launcher.py must run on Windows")
+        from windows.platform import set_process_dpi_awareness
+        set_process_dpi_awareness()
+    elif platform_name != "linux" or not sys.platform.startswith("linux"):
+        raise RuntimeError("unsupported desktop platform")
     _configure_logging()
 
     if _existing_instance_ready():
@@ -322,7 +336,7 @@ def main() -> int:
     )
     backend_thread.start()
     if not _wait_for_flask():
-        _show_error("Miru local service did not start. See LocalAppData\\Miru\\logs\\miru.log.")
+        _show_error(f"Miru local service did not start. See {support / 'logs' / 'miru.log'}.")
         return 1
 
     import webview
@@ -356,13 +370,13 @@ def main() -> int:
 
     storage = webview_storage_dir()
     storage.mkdir(parents=True, exist_ok=True)
-    icon = root / "src-tauri" / "icons" / "icon.ico"
+    icon = root / "src-tauri" / "icons" / ("128x128.png" if platform_name == "linux" else "icon.ico")
     debug_port = str(os.environ.get("MIRU_WEBVIEW_DEBUG_PORT") or "").strip()
     if debug_port:
         webview.settings["REMOTE_DEBUGGING_PORT"] = int(debug_port)
     try:
         webview.start(
-            gui="edgechromium",
+            gui="qt" if platform_name == "linux" else "edgechromium",
             private_mode=False,
             storage_path=str(storage),
             icon=str(icon) if icon.exists() else None,


### PR DESCRIPTION
Adds a source-run Ubuntu 22.04 X11 desktop entry point and Qt pet. The Linux entry point reuses the existing desktop lifecycle and native bridge in windows_launcher.py; both Linux windows use PySide6. Source setup is documented in docs/BUILDING.md. Wayland capture is not implemented.

Linux local-mode settings now describe the Linux computer in all four affected views: AI settings storage, account scope, invitation hints and account-switch confirmation. Linux source runs preserve terminal stderr for startup failures, while stdout continues to miru.log. Log-file chmod is best-effort. The existing non-Linux and remote-mode branches are preserved.

Validation for `3c5de42`:

- Full suite on Ubuntu 22.04.5: **917 passed**, 4 deselected, 5 expected failures. Secret scan and independent static review passed.
- Regression tests cover the four UI branches on Linux, Windows, macOS and Android in local and remote modes; port-conflict and backend-start diagnostics; chmod failure; packaged/windowless logging behavior.
- Real Qt/X11 run using Xvfb, isolated account/data and a local HTTPS model fixture: main window, local setup and onboarding passed; native capture probe returned 1440x1000.
- A real Qt pet process and mapped X11 window started. Minimize/restore emitted the Qt events and kept the backend and pet alive.
- The actual switch-account confirmation was clicked. Returning to local mode restored the same account and retained a chat record in that account's directory, verified through the page's authenticated history request.
- Closing the main window exited with code 0, released port 5001 and the fixture API port, and stopped the owned pet processes.
- With port 5001 occupied, the real launcher exited with code 1 and printed the port-conflict error to terminal stderr. The log file was still created with mode 0600.

The Xvfb run verifies Qt window-state events and process lifecycle; it does not exercise a desktop window manager's taskbar UI. A supplemental check supplied the documented Live2D resources from an existing local installation and verified HTTP 200 for the runtime, Cubism Core, model, moc and texture files. QtWebEngine then reported WebGL1 blocklisted in this Xvfb environment, so Live2D model rendering/animation is not claimed as passed. No GPU-blocklist bypass or additional product change was introduced for that check, and the third-party files are excluded from this PR.

<details>
<summary>Linux UI screenshots (stored separately from this PR's code changes)</summary>

AI configuration storage:

![Linux AI storage scope](https://raw.githubusercontent.com/Alice-Shimada/Miru/28e90689bbcb9f7d46413bface23daa63634e214/review-evidence/linux-owner-review/acceptance-linux-ai-storage.png)

Local invitation hint:

![Linux local invitation](https://raw.githubusercontent.com/Alice-Shimada/Miru/28e90689bbcb9f7d46413bface23daa63634e214/review-evidence/linux-owner-review/acceptance-linux-invitation.png)

Account scope:

![Linux account scope](https://raw.githubusercontent.com/Alice-Shimada/Miru/28e90689bbcb9f7d46413bface23daa63634e214/review-evidence/linux-owner-review/acceptance-linux-account.png)

Account-switch confirmation:

![Linux account switch](https://raw.githubusercontent.com/Alice-Shimada/Miru/28e90689bbcb9f7d46413bface23daa63634e214/review-evidence/linux-owner-review/acceptance-linux-switch-confirm.png)

</details>
